### PR TITLE
feat(): Pinned validators

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1494,6 +1494,7 @@ pub fn load_config(
     if genesis.is_none() || network_signer.is_none() {
         panic!("Genesis and network_signer should not be None by now.")
     }
+
     let near_config = NearConfig::new(
         config,
         genesis.unwrap(),


### PR DESCRIPTION
Any workspace that cares for security should run at least num_shards validators (potentially even factor_of_redundancy * num_shards). The proposed solution is to assign at least one validator from a workspace to each shard (depending on factor_of_redundancy, this can obviously be at least factor_of_redundancy).

For workspaces that do not care about security, their validators will be assigned falling back to the nearprotocol

Test plan:
Described here
https://docs.google.com/document/d/1Wc9b5eM3oQ57Ibe4RkzK3lUEZh3AAhQcx68_bcKH8yc/edit